### PR TITLE
fix: puts `sidecar.istio.io/inject` annotation in the right place

### DIFF
--- a/odh-dashboard/base/deployment.yaml
+++ b/odh-dashboard/base/deployment.yaml
@@ -11,11 +11,9 @@ spec:
     metadata:
       labels:
         deployment: odh-dashboard
+      annotations:
+        sidecar.istio.io/inject: "true"
     spec:
-      template:
-        metadata:
-          annotations:
-            sidecar.istio.io/inject: "true"
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
While trying to create custom `KfDef` resource operator fails with following error:

```
$ oc logs deployment/opendatahub-operator -n openshift-operators
...
time="2023-01-19T11:51:37Z" level=warning msg="Encountered error applying application odh-dashboard:  (kubefl
ow.error): Code 500 with message: Apply.Run : failed to create typed patch object (odh/odh-dashboard; apps/v1
, Kind=Deployment): .spec.template.spec.template: field not declared in schema"
...
```

This PR fixes the problem of putting the annotation in the right place.

On my Openshift instance though I'm getting a subsequent error when applying fixed Deployment though:

```
time="2023-01-19T12:14:22Z" level=error msg="Cannot create watch for resources Application app.k8s.io/v1beta1: no matches for kind \"Application\" in version \"app.k8s.io/v1beta1\"."
```

Something to investigate moving forward.